### PR TITLE
AMQ-8987 EncryptableLDAPLoginModule support wider password encryption…

### DIFF
--- a/activemq-jaas/src/main/java/org/apache/activemq/jaas/EncryptableLDAPLoginModule.java
+++ b/activemq-jaas/src/main/java/org/apache/activemq/jaas/EncryptableLDAPLoginModule.java
@@ -23,6 +23,7 @@ import javax.security.auth.callback.CallbackHandler;
 
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jasypt.encryption.pbe.config.EnvironmentStringPBEConfig;
+import org.jasypt.iv.RandomIvGenerator;
 import org.jasypt.properties.EncryptableProperties;
 
 /**
@@ -49,6 +50,10 @@ public class EncryptableLDAPLoginModule extends LDAPLoginModule {
 
         EnvironmentStringPBEConfig envConfig = new EnvironmentStringPBEConfig();
         envConfig.setAlgorithm(passwordAlgorithm);
+
+        if (passwordAlgorithm.startsWith("PBE") && passwordAlgorithm.contains("AES")) {
+            envConfig.setIvGenerator(new RandomIvGenerator());
+        }
 
         //If the password was set, use it
         //else look up the password from the environment

--- a/activemq-jaas/src/test/java/org/apache/activemq/jaas/LDAPLoginModuleTest.java
+++ b/activemq-jaas/src/test/java/org/apache/activemq/jaas/LDAPLoginModuleTest.java
@@ -146,6 +146,28 @@ public class LDAPLoginModuleTest extends AbstractLdapTestUnit {
     }
 
     @Test
+    public void testAESEncryptedLogin() throws LoginException {
+
+        LoginContext context = new LoginContext("EncryptedAESLDAPLogin", new CallbackHandler() {
+            @Override
+            public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException {
+                for (int i = 0; i < callbacks.length; i++) {
+                    if (callbacks[i] instanceof NameCallback) {
+                        ((NameCallback) callbacks[i]).setName("first");
+                    } else if (callbacks[i] instanceof PasswordCallback) {
+                        ((PasswordCallback) callbacks[i]).setPassword("secret".toCharArray());
+                    } else {
+                        throw new UnsupportedCallbackException(callbacks[i]);
+                    }
+                }
+            }
+        });
+        context.login();
+        context.logout();
+    }
+
+
+    @Test
     public void testUnauthenticated() throws LoginException {
         LoginContext context = new LoginContext("UnAuthenticatedLDAPLogin", new CallbackHandler() {
             @Override

--- a/activemq-jaas/src/test/resources/login.config
+++ b/activemq-jaas/src/test/resources/login.config
@@ -86,6 +86,27 @@ EncryptedLDAPLogin {
         ;
 };
 
+EncryptedAESLDAPLogin {
+    org.apache.activemq.jaas.EncryptableLDAPLoginModule required
+        debug=true
+        initialContextFactory=com.sun.jndi.ldap.LdapCtxFactory
+        connectionURL="ldap://localhost:1024"
+        connectionUsername="uid=admin,ou=system"
+        connectionPassword="ENC(l3ZDKzR+ADzlmYr2Csd/CBXnFRd5Jk02JGKaraMHc7NRQp5amOxvHbuUCQNUQ0cE)"
+        connectionProtocol=s
+        authentication=simple
+        userBase="ou=system"
+        userSearchMatching="(uid={0})"
+        userSearchSubtree=false
+        roleBase="ou=system"
+        roleName=dummyRoleName
+        roleSearchMatching="(uid={1})"
+        roleSearchSubtree=false
+        encryptionAlgorithm=PBEWITHHMACSHA256ANDAES_256
+        encryptionPassword="activemq"
+        ;
+};
+
 UnAuthenticatedLDAPLogin {
     org.apache.activemq.jaas.LDAPLoginModule required
         debug=true


### PR DESCRIPTION
… schemes

AMQ-8987

Description of changes:
Added support for wider password encryption schemes for EncryptableLDAPLoginModule. Similar to https://github.com/apache/activemq/pull/520, set IV generator for PBE-AES-based algorithms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.