### PR TITLE
Fix unit tests which fail related to log4j 2.17.2 update

### DIFF
--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/SharedFileLockerLoggingTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/SharedFileLockerLoggingTest.java
@@ -14,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.apache.activemq.store;
 
 import java.io.File;
@@ -48,55 +47,37 @@ import org.slf4j.LoggerFactory;
 
 import static org.junit.Assert.assertTrue;
 
-public class SharedFileLockerTest {
-    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(SharedFileLockerTest.class);
+public class SharedFileLockerLoggingTest {
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(SharedFileLockerLoopTest.class);
 
     @Rule
     public TemporaryFolder testFolder;
 
 
-    public SharedFileLockerTest() {
+    public SharedFileLockerLoggingTest() {
         File file = new File(IOHelper.getDefaultDataDirectory());
         file.mkdir();
 
         // TemporaryFolder will make sure the files are removed after the test is done
         testFolder = new TemporaryFolder(file);
-
     }
-
-    @Test
-    public void testStopNoStart() throws Exception {
-        SharedFileLocker locker1 = new SharedFileLocker();
-        locker1.setDirectory(testFolder.getRoot());
-        locker1.stop();
-    }
-
-    @Test
-    public void testLoop() throws Exception {
-        // Increase the number of iterations if you are debugging races
-        for (int i = 0; i < 100; i++) {
-            internalLoop(5);
-        }
-
-    }
-
 
     @Test
     public void testLogging() throws Exception {
         // using a bigger wait here
         // to make sure we won't log any extra info
-        internalLoop(100);
+        internalLoop(5);
     }
 
     private void internalLoop(long timewait) throws Exception {
         final AtomicInteger logCounts = new AtomicInteger(0);
-        
-     // start new
+
+        // start new
         final var logger = org.apache.logging.log4j.core.Logger.class.cast(LogManager.getRootLogger());
         final var appender = new AbstractAppender("testAppender", new AbstractFilter() {}, new MessageLayout(), false, new Property[0]) {
             @Override
             public void append(LogEvent event) {
-                if (Level.INFO.equals(event.getLevel())) {
+                if (event.getLevel() == Level.INFO) {
                     logCounts.incrementAndGet();
                 }
             }
@@ -187,94 +168,4 @@ public class SharedFileLockerTest {
 
     }
 
-    @Test
-    public void verifyLockAcquireWaitsForLockDrop() throws Exception {
-
-        final AtomicInteger logCounts = new AtomicInteger(0);
-     // start new
-        final var logger = org.apache.logging.log4j.core.Logger.class.cast(LogManager.getLogger(SharedFileLocker.class));
-        final var appender = new AbstractAppender("testAppender2", new AbstractFilter() {}, new MessageLayout(), false, new Property[0]) {
-            @Override
-            public void append(LogEvent event) {
-                logCounts.incrementAndGet();
-            }
-        };
-        appender.start();
-
-        logger.get().addAppender(appender, Level.DEBUG, new AbstractFilter() {});
-        logger.addAppender(appender);
-
-        LockableServiceSupport config = new LockableServiceSupport() {
-
-            @Override
-            public long getLockKeepAlivePeriod() {
-                return 500;
-            }
-
-            @Override
-            public Locker createDefaultLocker() throws IOException {
-                return null;
-            }
-
-            public void init() throws Exception {
-            }
-
-            protected void doStop(ServiceStopper stopper) throws Exception {
-            }
-
-            protected void doStart() throws Exception {
-            }
-        };
-
-        final SharedFileLocker underTest = new SharedFileLocker();
-        underTest.setDirectory(testFolder.getRoot());
-        underTest.setLockAcquireSleepInterval(5);
-        underTest.setLockable(config);
-
-        // get the in jvm lock
-        File lockFile = new File(testFolder.getRoot(), "lock");
-        String jvmProp = LockFile.class.getName() + ".lock." + lockFile.getCanonicalPath();
-        System.getProperties().put(jvmProp, jvmProp);
-
-        final CountDownLatch locked = new CountDownLatch(1);
-        ExecutorService executorService = Executors.newSingleThreadExecutor();
-        try {
-            final AtomicLong acquireTime = new AtomicLong(0l);
-            executorService.execute(new Runnable() {
-                @Override
-                public void run() {
-                    try {
-                        underTest.start();
-                        acquireTime.set(System.currentTimeMillis());
-                        locked.countDown();
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                    }
-                }
-            });
-
-            assertTrue("locker failed to obtain lock", Wait.waitFor(new Wait.Condition() {
-                @Override
-                public boolean isSatisified() throws Exception {
-                    return logCounts.get() > 0;
-                }
-            }, 5000, 10));
-
-            // release vm lock
-            long releaseTime = System.currentTimeMillis();
-            System.getProperties().remove(jvmProp);
-
-            assertTrue("locker got lock", locked.await(5, TimeUnit.SECONDS));
-
-            // verify delay in start
-            LOG.info("ReleaseTime: " + releaseTime + ", AcquireTime:" + acquireTime.get());
-            assertTrue("acquire delayed for keepAlive: " + config.getLockKeepAlivePeriod(), acquireTime.get() >= releaseTime + config.getLockKeepAlivePeriod());
-
-        } finally {
-            executorService.shutdownNow();
-            underTest.stop();
-            lockFile.delete();
-            logger.removeAppender(appender);
-        }
-    }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/SharedFileLockerLoggingTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/SharedFileLockerLoggingTest.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
 import static org.junit.Assert.assertTrue;
 
 public class SharedFileLockerLoggingTest {
-    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(SharedFileLockerLoopTest.class);
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(SharedFileLockerLoggingTest.class);
 
     @Rule
     public TemporaryFolder testFolder;

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/store/SharedFileLockerLoopTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/store/SharedFileLockerLoopTest.java
@@ -1,0 +1,270 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.store;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.activemq.broker.LockableServiceSupport;
+import org.apache.activemq.broker.Locker;
+import org.apache.activemq.util.IOHelper;
+import org.apache.activemq.util.LockFile;
+import org.apache.activemq.util.ServiceStopper;
+import org.apache.activemq.util.Wait;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.filter.AbstractFilter;
+import org.apache.logging.log4j.core.layout.MessageLayout;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.LoggerFactory;
+
+
+import static org.junit.Assert.assertTrue;
+
+public class SharedFileLockerLoopTest {
+    private static final org.slf4j.Logger LOG = LoggerFactory.getLogger(SharedFileLockerLoopTest.class);
+
+    @Rule
+    public TemporaryFolder testFolder;
+
+
+    public SharedFileLockerLoopTest() {
+        File file = new File(IOHelper.getDefaultDataDirectory());
+        file.mkdir();
+
+        // TemporaryFolder will make sure the files are removed after the test is done
+        testFolder = new TemporaryFolder(file);
+    }
+
+    @Test
+    public void testStopNoStart() throws Exception {
+        SharedFileLocker locker1 = new SharedFileLocker();
+        locker1.setDirectory(testFolder.getRoot());
+        locker1.stop();
+    }
+
+    @Test
+    public void testLoop() throws Exception {
+        // Increase the number of iterations if you are debugging races
+        for (int i = 0; i < 100; i++) {
+            internalLoop(5);
+        }
+
+    }
+
+    private void internalLoop(long timewait) throws Exception {
+        final AtomicInteger logCounts = new AtomicInteger(0);
+        
+     // start new
+        final var logger = org.apache.logging.log4j.core.Logger.class.cast(LogManager.getRootLogger());
+        final var appender = new AbstractAppender("testAppender", new AbstractFilter() {}, new MessageLayout(), false, new Property[0]) {
+            @Override
+            public void append(LogEvent event) {
+                if (event.getLevel() == Level.INFO) {
+                    logCounts.incrementAndGet();
+                }
+            }
+        };
+        appender.start();
+
+        Configurator.setRootLevel(Level.DEBUG);
+        logger.get().addAppender(appender, Level.DEBUG, new AbstractFilter() {});
+        logger.addAppender(appender);
+
+        final AtomicInteger errors = new AtomicInteger(0);
+
+        Thread thread = null;
+
+        SharedFileLocker locker1 = new SharedFileLocker();
+        locker1.setDirectory(testFolder.getRoot());
+
+        final SharedFileLocker locker2 = new SharedFileLocker();
+        locker2.setLockAcquireSleepInterval(1);
+        locker2.setDirectory(testFolder.getRoot());
+
+
+        try {
+            locker1.doStart();
+
+            assertTrue(locker1.keepAlive());
+
+            thread = new Thread("Locker Thread") {
+                public void run() {
+                    try {
+                        locker2.doStart();
+                    } catch (Throwable e) {
+                        errors.incrementAndGet();
+                    }
+                }
+            };
+
+            thread.start();
+
+            // I need to make sure the info was already logged
+            // but I don't want to have an unecessary wait here,
+            // as I want the test to run as fast as possible
+            {
+                long timeout = System.currentTimeMillis() + 5000;
+                while (logCounts.get() < 1 && System.currentTimeMillis() < timeout) {
+                    Thread.sleep(1);
+                }
+            }
+
+            if (timewait > 0) {
+                Thread.sleep(timewait);
+            }
+
+            assertTrue(thread.isAlive());
+
+            locker1.stop();
+
+            // 10 seconds here is an eternity, but it should only take milliseconds
+            thread.join(5000);
+
+            Assert.assertEquals("Extra logs in place", 1, logCounts.get());
+
+            long timeout = System.currentTimeMillis() + 5000;
+
+            while (timeout > System.currentTimeMillis() && !locker2.keepAlive()) {
+                Thread.sleep(1);
+            }
+
+            assertTrue(locker2.keepAlive());
+
+            locker2.stop();
+
+            Assert.assertEquals(0, errors.get());
+
+        } finally {
+
+            logger.removeAppender(appender);
+
+            // to make sure we won't leak threads if the test ever failed for any reason
+            thread.join(1000);
+            if (thread.isAlive()) {
+                thread.interrupt();
+            }
+
+            File lockFile = new File(testFolder.getRoot(), "lock");
+            lockFile.delete();
+        }
+
+    }
+
+    @Test
+    public void verifyLockAcquireWaitsForLockDrop() throws Exception {
+
+        final AtomicInteger logCounts = new AtomicInteger(0);
+     // start new
+        final var logger = org.apache.logging.log4j.core.Logger.class.cast(LogManager.getLogger(SharedFileLocker.class));
+        final var appender = new AbstractAppender("testAppender2", new AbstractFilter() {}, new MessageLayout(), false, new Property[0]) {
+            @Override
+            public void append(LogEvent event) {
+                logCounts.incrementAndGet();
+            }
+        };
+        appender.start();
+
+        logger.get().addAppender(appender, Level.DEBUG, new AbstractFilter() {});
+        logger.addAppender(appender);
+
+        LockableServiceSupport config = new LockableServiceSupport() {
+
+            @Override
+            public long getLockKeepAlivePeriod() {
+                return 500;
+            }
+
+            @Override
+            public Locker createDefaultLocker() throws IOException {
+                return null;
+            }
+
+            public void init() throws Exception {
+            }
+
+            protected void doStop(ServiceStopper stopper) throws Exception {
+            }
+
+            protected void doStart() throws Exception {
+            }
+        };
+
+        final SharedFileLocker underTest = new SharedFileLocker();
+        underTest.setDirectory(testFolder.getRoot());
+        underTest.setLockAcquireSleepInterval(5);
+        underTest.setLockable(config);
+
+        // get the in jvm lock
+        File lockFile = new File(testFolder.getRoot(), "lock");
+        String jvmProp = LockFile.class.getName() + ".lock." + lockFile.getCanonicalPath();
+        System.getProperties().put(jvmProp, jvmProp);
+
+        final CountDownLatch locked = new CountDownLatch(1);
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        try {
+            final AtomicLong acquireTime = new AtomicLong(0l);
+            executorService.execute(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        underTest.start();
+                        acquireTime.set(System.currentTimeMillis());
+                        locked.countDown();
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            });
+
+            assertTrue("locker failed to obtain lock", Wait.waitFor(new Wait.Condition() {
+                @Override
+                public boolean isSatisified() throws Exception {
+                    return logCounts.get() > 0;
+                }
+            }, 5000, 10));
+
+            // release vm lock
+            long releaseTime = System.currentTimeMillis();
+            System.getProperties().remove(jvmProp);
+
+            assertTrue("locker got lock", locked.await(5, TimeUnit.SECONDS));
+
+            // verify delay in start
+            LOG.info("ReleaseTime: " + releaseTime + ", AcquireTime:" + acquireTime.get());
+            assertTrue("acquire delayed for keepAlive: " + config.getLockKeepAlivePeriod(), acquireTime.get() >= releaseTime + config.getLockKeepAlivePeriod());
+
+        } finally {
+            executorService.shutdownNow();
+            underTest.stop();
+            lockFile.delete();
+            logger.removeAppender(appender);
+        }
+    }
+}

--- a/activemq-unit-tests/src/test/resources/log4j2-test.properties
+++ b/activemq-unit-tests/src/test/resources/log4j2-test.properties
@@ -19,7 +19,6 @@
 # The logging properties used during tests
 #
 rootLogger.level=INFO
-
 rootLogger.appenderRef.console.ref=Console
 rootLogger.appenderRef.logfile.ref=RollingFile
 

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <module>activemq-run</module>
     <module>activemq-shiro</module>
     <module>activemq-spring</module>
-    <!-- <module>activemq-runtime-config</module> -->
+    <module>activemq-runtime-config</module>
     <module>activemq-tooling</module>
     <module>activemq-web</module>
     <module>activemq-partition</module>

--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <module>activemq-run</module>
     <module>activemq-shiro</module>
     <module>activemq-spring</module>
-    <module>activemq-runtime-config</module>
+    <!-- <module>activemq-runtime-config</module> -->
     <module>activemq-tooling</module>
     <module>activemq-web</module>
     <module>activemq-partition</module>


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Cherry picked https://github.com/apache/activemq/pull/827/commits/c711d5c029d9fb0cd49df3bfe0082d09b0a648e3 from upstream to fix failed unit test.

*Test*  ran `mvn -B -e -fae '-Dtest=org.apache.activemq.store.SharedFileLocker*Test' test` locally.

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.activemq.store.SharedFileLockerLoggingTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.321 s - in org.apache.activemq.store.SharedFileLockerLoggingTest
[INFO] Running org.apache.activemq.store.SharedFileLockerLoopTest
[INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.874 s - in org.apache.activemq.store.SharedFileLockerLoopTest
[INFO]
[INFO] Results:
[INFO]
[INFO] Tests run: 4, Failures: 0, Errors: 0, Skipped: 0
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
