### PR TITLE
mirrored queue does not mirror replication queues

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/MirroredQueue.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/MirroredQueue.java
@@ -26,6 +26,8 @@ import org.apache.activemq.command.Message;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.activemq.replica.ReplicaSupport.isReplicationDestination;
+
 /**
  * Creates <a href="https://activemq.apache.org/mirrored-queues">Mirrored
  * Queue</a> using a prefix and postfix to define the topic name on which to mirror the queue to.
@@ -41,7 +43,7 @@ public class MirroredQueue implements DestinationInterceptor, BrokerServiceAware
     private BrokerService brokerService;
 
     public Destination intercept(final Destination destination) {
-        if (destination.getActiveMQDestination().isQueue()) {
+        if (destination.getActiveMQDestination().isQueue() && !isReplicationDestination(destination)) {
             if (!destination.getActiveMQDestination().isTemporary() || brokerService.isUseTempMirroredQueues()) {
                 try {
                     final Destination mirrorDestination = getMirrorDestination(destination);

--- a/activemq-broker/src/main/java/org/apache/activemq/replica/ReplicaSupport.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/replica/ReplicaSupport.java
@@ -19,6 +19,7 @@ package org.apache.activemq.replica;
 import org.apache.activemq.advisory.AdvisorySupport;
 import org.apache.activemq.broker.Connector;
 import org.apache.activemq.broker.TransportConnector;
+import org.apache.activemq.broker.region.Destination;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.util.LongSequenceGenerator;
 
@@ -77,6 +78,10 @@ public class ReplicaSupport {
 
     public static boolean isReplicationDestination(ActiveMQDestination destination) {
         return REPLICATION_DESTINATION_NAMES.contains(destination.getPhysicalName());
+    }
+
+    public static boolean isReplicationDestination(Destination destination) {
+        return REPLICATION_DESTINATION_NAMES.contains(destination.getName());
     }
 
     public static boolean isMainReplicationQueue(ActiveMQDestination destination) {

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/replica/ReplicaPluginMirrorQueueTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/replica/ReplicaPluginMirrorQueueTest.java
@@ -1,0 +1,138 @@
+package org.apache.activemq.broker.replica;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.ActiveMQXAConnectionFactory;
+import org.apache.activemq.broker.BrokerPlugin;
+import org.apache.activemq.broker.BrokerService;
+import org.apache.activemq.broker.jmx.QueueViewMBean;
+import org.apache.activemq.broker.region.DestinationInterceptor;
+import org.apache.activemq.broker.region.policy.PolicyEntry;
+import org.apache.activemq.broker.region.policy.PolicyMap;
+import org.apache.activemq.broker.region.virtual.MirroredQueue;
+import org.apache.activemq.command.ActiveMQTextMessage;
+import org.apache.activemq.replica.ReplicaPlugin;
+import org.apache.activemq.replica.ReplicaRole;
+import org.apache.activemq.replica.ReplicaSupport;
+import org.apache.activemq.util.Wait;
+
+import javax.jms.Connection;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.XAConnection;
+
+public class ReplicaPluginMirrorQueueTest extends ReplicaPluginTestSupport {
+
+    protected Connection firstBrokerConnection;
+    protected Connection secondBrokerConnection;
+
+    @Override
+    protected void setUp() throws Exception {
+        firstBroker = createFirstMirroredBroker();
+        secondBroker = createSecondBroker();
+
+        startFirstBroker();
+        startSecondBroker();
+
+        firstBrokerConnectionFactory = new ActiveMQConnectionFactory(firstBindAddress);
+        secondBrokerConnectionFactory = new ActiveMQConnectionFactory(secondBindAddress);
+
+        destination = createDestination();
+
+        firstBrokerConnection = firstBrokerConnectionFactory.createConnection();
+        firstBrokerConnection.start();
+
+        secondBrokerConnection = secondBrokerConnectionFactory.createConnection();
+        secondBrokerConnection.start();
+
+        waitUntilReplicationQueueHasConsumer(firstBroker);
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        if (firstBrokerConnection != null) {
+            firstBrokerConnection.close();
+            firstBrokerConnection = null;
+        }
+        if (secondBrokerConnection != null) {
+            secondBrokerConnection.close();
+            secondBrokerConnection = null;
+        }
+
+        super.tearDown();
+    }
+
+    public void testSendMessage() throws Exception {
+        Session firstBrokerSession = firstBrokerConnection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+        MessageProducer firstBrokerProducer = firstBrokerSession.createProducer(destination);
+        MessageConsumer firstBrokerConsumer = firstBrokerSession.createConsumer(destination);
+
+        Session secondBrokerSession = secondBrokerConnection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+        MessageConsumer secondBrokerConsumer = secondBrokerSession.createConsumer(destination);
+
+        ActiveMQTextMessage message  = new ActiveMQTextMessage();
+        message.setText(getName());
+        firstBrokerProducer.send(message);
+
+        Message receivedMessage = secondBrokerConsumer.receive(LONG_TIMEOUT);
+        assertNull(receivedMessage);
+
+        receivedMessage = firstBrokerConsumer.receive(SHORT_TIMEOUT);
+        assertNotNull(receivedMessage);
+        assertTrue(receivedMessage instanceof TextMessage);
+        assertEquals(getName(), ((TextMessage) receivedMessage).getText());
+
+        receivedMessage.acknowledge();
+
+        Thread.sleep(LONG_TIMEOUT);
+        secondBrokerSession.close();
+        secondBrokerSession = secondBrokerConnection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+        secondBrokerConsumer = secondBrokerSession.createConsumer(destination);
+
+        receivedMessage = secondBrokerConsumer.receive(SHORT_TIMEOUT);
+        assertNull(receivedMessage);
+
+        firstBrokerSession.close();
+        secondBrokerSession.close();
+    }
+
+    private BrokerService createFirstMirroredBroker() throws Exception {
+        BrokerService answer = new BrokerService();
+        answer.setUseJmx(true);
+        answer.setPersistent(false);
+        answer.getManagementContext().setCreateConnector(false);
+        answer.addConnector(firstBindAddress);
+        answer.setDataDirectory(FIRST_KAHADB_DIRECTORY);
+        answer.setBrokerName("firstBroker");
+        answer.setUseMirroredQueues(true);
+
+        ReplicaPlugin replicaPlugin = new ReplicaPlugin();
+        replicaPlugin.setRole(ReplicaRole.source);
+        replicaPlugin.setTransportConnectorUri(firstReplicaBindAddress);
+        replicaPlugin.setOtherBrokerUri(secondReplicaBindAddress);
+        replicaPlugin.setControlWebConsoleAccess(false);
+        replicaPlugin.setHeartBeatPeriod(0);
+
+        answer.setPlugins(new BrokerPlugin[]{replicaPlugin});
+        answer.setSchedulerSupport(true);
+        return answer;
+    }
+
+    private void waitUntilReplicationQueueHasConsumer(BrokerService broker) throws Exception {
+        assertTrue("Replication Main Queue has Consumer",
+                Wait.waitFor(new Wait.Condition() {
+                    @Override
+                    public boolean isSatisified() throws Exception {
+                        try {
+                            QueueViewMBean brokerMainQueueView = getQueueView(broker, ReplicaSupport.MAIN_REPLICATION_QUEUE_NAME);
+                            return brokerMainQueueView.getConsumerCount() > 0;
+                        } catch (Exception e) {
+                            e.printStackTrace();
+                            return false;
+                        }
+                    }
+                }, Wait.MAX_WAIT_MILLIS*2));
+    }
+}


### PR DESCRIPTION

*Description of changes:*


When mirroredQueue option is enabled, messages replication queues got mirrored, which then being replicated again by replication queue, and caused stackoverflow issue eventually. This fix stops message from replication queue being mirrored. The reason we cannot put the fix in replication plugin code is because [intercept](https://github.com/amazon-mq/upstreaming-activemq/blob/feature/replica_broker/activemq-broker/src/main/java/org/apache/activemq/broker/region/virtual/MirroredQueue.java#L49) function in MirroredQueue creates an anonymous function override. It's difficult for us to distinguish message from mirrored queue. 


*Tests*:
- added unit test.
- run all replication plugin tests. 
```
[INFO] Results:
[INFO]
[INFO] Tests run: 83, Failures: 0, Errors: 0, Skipped: 0
[INFO]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  37:13 min
[INFO] Finished at: 2024-01-16T16:14:51-08:00
[INFO] ------------------------------------------------------------------------
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
