### PR TITLE
CRDR does not replicate messages fanned out from Virtual Topics.

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/replica/ReplicaDestinationFilter.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/replica/ReplicaDestinationFilter.java
@@ -21,19 +21,28 @@ import org.apache.activemq.broker.ProducerBrokerExchange;
 import org.apache.activemq.broker.region.Destination;
 import org.apache.activemq.broker.region.DestinationFilter;
 import org.apache.activemq.broker.region.virtual.CompositeDestinationFilter;
+import org.apache.activemq.broker.region.virtual.MappedQueueFilter;
+import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.Message;
 import org.apache.activemq.command.TransactionId;
 import org.apache.activemq.replica.source.ReplicaEventReplicator;
 import org.apache.activemq.replica.util.ReplicaRole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ReplicaDestinationFilter extends DestinationFilter {
     private final boolean nextIsComposite;
+    private final boolean nextIsMappedQueue;
+
     private final ReplicaEventReplicator replicaEventReplicator;
     private final ReplicaRoleManagementBroker roleManagementBroker;
+
+    private final Logger logger = LoggerFactory.getLogger(ReplicaDestinationFilter.class);
 
     public ReplicaDestinationFilter(Destination next, ReplicaEventReplicator replicaEventReplicator, ReplicaRoleManagementBroker roleManagementBroker) {
         super(next);
         this.nextIsComposite = this.next != null && this.next instanceof CompositeDestinationFilter;
+        this.nextIsMappedQueue = this.next != null && this.next instanceof MappedQueueFilter; // Used by Virtual Topics
         this.replicaEventReplicator = replicaEventReplicator;
         this.roleManagementBroker = roleManagementBroker;
     }
@@ -43,6 +52,15 @@ public class ReplicaDestinationFilter extends DestinationFilter {
         if(ReplicaRole.source == roleManagementBroker.getRole()) {
             super.send(producerExchange, messageSend);
             if(!nextIsComposite) {
+                // Don't replicate messages to Virtual Topics Consumer Queues. Instead, let the Replica Broker fan out
+                // again when the topic message is replicated, so we prevent message duplication.
+                if (isVirtualTopicFanOut(messageSend)) {
+                    logger.trace("Destination of message '{}' is a virtual topic ('{}') fan-out: '{}'. Not replicating it.",
+                            messageSend.getMessageId(),
+                            messageSend.getOriginalDestination().getQualifiedName(),
+                            messageSend.getDestination());
+                    return;
+                }
                 // don't replicate composite destination
                 replicateSend(producerExchange, messageSend);
             }
@@ -62,6 +80,20 @@ public class ReplicaDestinationFilter extends DestinationFilter {
             return super.canGC();
         }
         return false;
+    }
+
+    private boolean isVirtualTopicFanOut(Message message) {
+        final ActiveMQDestination destination = message.getDestination();
+        if (destination == null) {
+            return false;
+        }
+
+        final ActiveMQDestination originalDest = message.getOriginalDestination();
+        if (originalDest == null) {
+            return false;
+        }
+
+        return nextIsMappedQueue && destination.isQueue() && originalDest.isTopic();
     }
 
     private void replicateSend(ProducerBrokerExchange producerExchange, Message messageSend) throws Exception {

--- a/activemq-broker/src/main/java/org/apache/activemq/replica/source/ReplicaBatcher.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/replica/source/ReplicaBatcher.java
@@ -21,6 +21,8 @@ import org.apache.activemq.command.ActiveMQMessage;
 import org.apache.activemq.replica.util.ReplicaEventType;
 import org.apache.activemq.replica.ReplicaPolicy;
 import org.apache.activemq.replica.util.ReplicaSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,6 +34,7 @@ import java.util.Set;
 public class ReplicaBatcher {
 
     private final ReplicaPolicy replicaPolicy;
+    private static final Logger logger = LoggerFactory.getLogger(ReplicaBatcher.class);
 
     public ReplicaBatcher(ReplicaPolicy replicaPolicy) {
         this.replicaPolicy = replicaPolicy;
@@ -41,14 +44,27 @@ public class ReplicaBatcher {
     List<List<MessageReference>> batches(List<MessageReference> list) throws Exception {
         List<List<MessageReference>> result = new ArrayList<>();
 
-        Map<String, Set<String>> destination2eventType = new HashMap<>();
+        final Map<String, Set<String>> destination2eventType = new HashMap<>();
+
+        // Tracks SEND messages within the current batch targeting topic destinations, so we can use it to avoid putting
+        // these SENDs and their corresponding ACKs in the same batch. This is important for Virtual Topics:
+        //
+        // Once the SEND message reaches the Replica broker it will fan out to their corresponding consumer queues. If an
+        // ACK is replicated in the same batch it will result in the Replica trying to replay the ACK in the same transaction
+        // as the fanned out messages. Because the transaction is still open, the messages won't be visible and the ACK will fail.
+        // It results in messages never being ACKed in the replica broker.
+        //
+        // This is only a problem for Virtual Topics fanned out messages because their "SEND" is not replicated, instead we let the
+        // Replica broker fan out them again. Therefore, the compactor will not match SENDs and ACKs.
+        final Set<String> batchedMessageIdsSentToTopics = new HashSet<>();
+
         List<MessageReference> batch = new ArrayList<>();
+
         int batchSize = 0;
         for (MessageReference reference : list) {
-            ActiveMQMessage message = (ActiveMQMessage) reference.getMessage();
-            String originalDestination = message.getStringProperty(ReplicaSupport.ORIGINAL_MESSAGE_DESTINATION_PROPERTY);
-            ReplicaEventType currentEventType =
-                    ReplicaEventType.valueOf(message.getStringProperty(ReplicaEventType.EVENT_TYPE_PROPERTY));
+            final ActiveMQMessage message = (ActiveMQMessage) reference.getMessage();
+            final String originalDestination = message.getStringProperty(ReplicaSupport.ORIGINAL_MESSAGE_DESTINATION_PROPERTY);
+            final ReplicaEventType currentEventType = ReplicaEventType.valueOf(message.getStringProperty(ReplicaEventType.EVENT_TYPE_PROPERTY));
 
             if (ReplicaEventType.TRANSACTIONLESS_EVENT_TYPES.contains(currentEventType)) {
                 if (!batch.isEmpty()) {
@@ -59,20 +75,35 @@ public class ReplicaBatcher {
                 batch.add(reference);
                 result.add(batch);
                 batch = new ArrayList<>();
+                batchedMessageIdsSentToTopics.clear();
                 continue;
             }
 
             boolean eventTypeSwitch = false;
+            boolean shouldTrackTopicSend = false; // See batchedMessageIdsSentToTopics
             if (originalDestination != null) {
-                Set<String> sends = destination2eventType.computeIfAbsent(originalDestination, k -> new HashSet<>());
+                final Set<String> sends = destination2eventType.computeIfAbsent(originalDestination, k -> new HashSet<>());
+
                 if (currentEventType == ReplicaEventType.MESSAGE_SEND) {
                     sends.add(message.getStringProperty(ReplicaSupport.MESSAGE_ID_PROPERTY));
+
+                    final boolean originalMessageWasSentToTopic = !message.getBooleanProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_SENT_TO_QUEUE_PROPERTY);
+                    final boolean messageWasInXATransaction = message.getBooleanProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_IN_XA_TRANSACTION_PROPERTY);
+                    if (originalMessageWasSentToTopic && !messageWasInXATransaction) {
+                        logger.trace("Message {} was sent to a Topic Destination: {}", message, originalDestination);
+                        shouldTrackTopicSend = true;
+                    }
                 }
                 if (currentEventType == ReplicaEventType.MESSAGE_ACK) {
-                    List<String> stringProperty = (List<String>) message.getProperty(ReplicaSupport.MESSAGE_IDS_PROPERTY);
-                    if (sends.stream().anyMatch(stringProperty::contains)) {
+                    final List<String> messageIds = (List<String>) message.getProperty(ReplicaSupport.MESSAGE_IDS_PROPERTY);
+                    if (sends.stream().anyMatch(messageIds::contains)) {
                         destination2eventType.put(originalDestination, new HashSet<>());
                         eventTypeSwitch = true;
+                    }  else {
+                        eventTypeSwitch = batchedMessageIdsSentToTopics.stream() // Prevents topic SEND-ACK pairs from being batched together.
+                                .filter(messageIds::contains)
+                                .peek(messageId -> logger.trace("Message {} was ACK to a previous topic SEND: {}", messageId, originalDestination))
+                                .findAny().isPresent();
                     }
                 }
             }
@@ -83,6 +114,13 @@ public class ReplicaBatcher {
                 result.add(batch);
                 batch = new ArrayList<>();
                 batchSize = 0;
+                batchedMessageIdsSentToTopics.clear();
+                logger.trace("Building a new batch");
+            }
+
+            if (shouldTrackTopicSend) {
+                // Must be done after checking if the batch as exceeded the size limit. Otherwise, this message ID may not be tracked.
+                batchedMessageIdsSentToTopics.add(message.getStringProperty(ReplicaSupport.MESSAGE_ID_PROPERTY));
             }
 
             batch.add(reference);

--- a/activemq-broker/src/test/java/org/apache/activemq/replica/ReplicaDestinationFilterTest.java
+++ b/activemq-broker/src/test/java/org/apache/activemq/replica/ReplicaDestinationFilterTest.java
@@ -1,0 +1,225 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.replica;
+
+import org.apache.activemq.broker.ConnectionContext;
+import org.apache.activemq.broker.ProducerBrokerExchange;
+import org.apache.activemq.broker.region.Destination;
+import org.apache.activemq.broker.region.virtual.CompositeDestinationFilter;
+import org.apache.activemq.broker.region.virtual.MappedQueueFilter;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.apache.activemq.command.LocalTransactionId;
+import org.apache.activemq.command.Message;
+import org.apache.activemq.command.ConnectionId;
+import org.apache.activemq.command.Response;
+import org.apache.activemq.replica.source.ReplicaEventReplicator;
+import org.apache.activemq.replica.util.ReplicaRole;
+import org.apache.activemq.state.CommandVisitor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import javax.jms.JMSException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ReplicaDestinationFilterTest {
+    @Mock
+    private Destination destination;
+
+    @Mock
+    private ActiveMQDestination activeMQDestination;
+
+    @Mock
+    private ReplicaEventReplicator replicaEventReplicator;
+
+    @Mock
+    private ReplicaRoleManagementBroker roleManagementBroker;
+
+    @Mock
+    private ProducerBrokerExchange producerExchange;
+
+    @Mock
+    private ConnectionContext connectionContext;
+
+    private Message message;
+
+    @Before
+    public void setUp() {
+        when(producerExchange.getConnectionContext()).thenReturn(connectionContext);
+
+        message = new StubMessage();
+        message.setDestination(activeMQDestination);
+        when(replicaEventReplicator.needToReplicateSend(connectionContext, message)).thenReturn(true); // Needs to replicate unless stated otherwise
+    }
+
+    @Test
+    public void givenIsSourceWhenSendMessageThenReplicateSend() throws Exception {
+        setIsSource();
+
+        ReplicaDestinationFilter filter = new ReplicaDestinationFilter(destination, replicaEventReplicator, roleManagementBroker);
+        filter.send(producerExchange, message);
+
+        verify(destination).send(producerExchange, message);
+        verify(replicaEventReplicator).replicateSend(eq(connectionContext), eq(message), any());
+    }
+
+    @Test
+    public void givenIsSourceWhenReplicationNotNeededThenDoNotReplicate() throws Exception {
+        setIsSource();
+
+        when(replicaEventReplicator.needToReplicateSend(connectionContext, message)).thenReturn(false);
+
+        ReplicaDestinationFilter filter = new ReplicaDestinationFilter(destination, replicaEventReplicator, roleManagementBroker);
+        filter.send(producerExchange, message);
+
+        verify(destination).send(producerExchange, message);
+        verify(replicaEventReplicator, never()).replicateSend(any(), any(), any());
+    }
+
+    @Test
+    public void givenIsSourceWhenCompositeDestinationThenDoNotReplicate() throws Exception {
+        setIsSource();
+
+        CompositeDestinationFilter compositeDestination = mock(CompositeDestinationFilter.class);
+
+        ReplicaDestinationFilter filter = new ReplicaDestinationFilter(compositeDestination, replicaEventReplicator, roleManagementBroker);
+        filter.send(producerExchange, message);
+
+        verify(compositeDestination).send(producerExchange, message);
+        verify(replicaEventReplicator, never()).replicateSend(any(), any(), any());
+    }
+
+    @Test
+    public void givenIsReplicaWhenSendMessageThenDelegateToNext() throws Exception {
+        setIsReplica();
+
+        ReplicaDestinationFilter filter = new ReplicaDestinationFilter(destination, replicaEventReplicator, roleManagementBroker);
+        filter.send(producerExchange, message);
+
+        verify(destination).send(producerExchange, message);
+        verify(replicaEventReplicator, never()).replicateSend(any(), any(), any());
+    }
+
+    @Test
+    public void givenIsReplicaWhenCompositeDestinationThenSkipCompositeFilter() throws Exception {
+        setIsReplica();
+
+        CompositeDestinationFilter compositeDestination = mock(CompositeDestinationFilter.class);
+        Destination innerDestination = mock(Destination.class);
+        when(compositeDestination.getNext()).thenReturn(innerDestination);
+
+        ReplicaDestinationFilter filter = new ReplicaDestinationFilter(compositeDestination, replicaEventReplicator, roleManagementBroker);
+        filter.send(producerExchange, message);
+
+        verify(innerDestination).send(producerExchange, message);
+        verify(compositeDestination, never()).send(producerExchange, message);
+    }
+
+    @Test
+    public void givenIsSourceWhenSendWithLocalTransactionThenPassTransactionId() throws Exception {
+        setIsSource();
+
+        LocalTransactionId txId = new LocalTransactionId(new ConnectionId("conn"), 1);
+        message.setTransactionId(txId);
+
+        ReplicaDestinationFilter filter = new ReplicaDestinationFilter(destination, replicaEventReplicator, roleManagementBroker);
+        filter.send(producerExchange, message);
+
+        verify(replicaEventReplicator).replicateSend(connectionContext, message, txId);
+    }
+
+    @Test
+    public void givenIsSourceWhenCanGCThenDelegateToNext() {
+        setIsSource();
+        when(destination.canGC()).thenReturn(true);
+
+        ReplicaDestinationFilter filter = new ReplicaDestinationFilter(destination, replicaEventReplicator, roleManagementBroker);
+        assertTrue(filter.canGC());
+    }
+
+    @Test
+    public void givenIsReplicaWhenCanGCThenReturnFalse() {
+        setIsReplica();
+
+        ReplicaDestinationFilter filter = new ReplicaDestinationFilter(destination, replicaEventReplicator, roleManagementBroker);
+        assertFalse(filter.canGC());
+    }
+
+    @Test
+    public void givenIsSourceWhenIsVirtualTopicFanoutThenDoNotReplicate() throws Exception {
+        setIsSource();
+
+        when(activeMQDestination.isQueue()).thenReturn(true); // Message is sent to queue
+
+        final ActiveMQDestination originalDestination = mock(ActiveMQDestination.class);
+        when(originalDestination.isTopic()).thenReturn(true); // Original destination is a topic, this is a message to a virtual topic consumer queue.
+
+        message.setOriginalDestination(originalDestination);
+
+        final MappedQueueFilter virtualTopicDestination = new MappedQueueFilter(activeMQDestination, destination);
+
+        ReplicaDestinationFilter filter = new ReplicaDestinationFilter(virtualTopicDestination, replicaEventReplicator, roleManagementBroker);
+        filter.send(producerExchange, message);
+
+        verify(replicaEventReplicator, never()).replicateSend(any(), any(), any());
+    }
+
+    private void setIsSource() {
+        when(roleManagementBroker.getRole()).thenReturn(ReplicaRole.source);
+    }
+
+    private void setIsReplica() {
+        when(roleManagementBroker.getRole()).thenReturn(ReplicaRole.replica);
+    }
+
+    private static final class StubMessage extends Message {
+        @Override
+        public Message copy() {
+            return new StubMessage();
+        }
+
+        @Override
+        public void clearBody() throws JMSException {}
+
+        @Override
+        public void storeContent() {}
+
+        @Override
+        public void storeContentAndClear() {}
+
+        @Override
+        public Response visit(CommandVisitor visitor) throws Exception {
+            return new Response();
+        }
+
+        @Override
+        public byte getDataStructureType() {
+            return 0;
+        }
+    }
+}

--- a/activemq-broker/src/test/java/org/apache/activemq/replica/source/ReplicaBatcherTest.java
+++ b/activemq-broker/src/test/java/org/apache/activemq/replica/source/ReplicaBatcherTest.java
@@ -22,7 +22,6 @@ import org.apache.activemq.command.ConsumerId;
 import org.apache.activemq.command.Message;
 import org.apache.activemq.command.MessageId;
 import org.apache.activemq.replica.ReplicaPolicy;
-import org.apache.activemq.replica.source.ReplicaBatcher;
 import org.apache.activemq.replica.util.ReplicaEventType;
 import org.apache.activemq.replica.util.ReplicaSupport;
 import org.junit.Test;
@@ -202,6 +201,110 @@ public class ReplicaBatcherTest {
         assertThat(batches.get(0).get(0).getMessageId().toString()).isEqualTo("1:0:0:1");
         assertThat(batches.get(0).get(1).getMessageId().toString()).isEqualTo("1:0:0:2");
         assertThat(batches.get(1).get(0).getMessageId().toString()).isEqualTo("1:0:0:3");
+    }
+
+    @Test
+    public void batchesTopicAckMessageSeparately() throws Exception {
+        final List<MessageReference> list = new ArrayList<>();
+
+        final String firstTopicSendMessageId = "1:0:0:1";
+        final ActiveMQMessage firstTopicSend = new ActiveMQMessage();
+        firstTopicSend.setStringProperty(ReplicaSupport.ORIGINAL_MESSAGE_DESTINATION_PROPERTY, "VirtualTopic.Orders");
+        firstTopicSend.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_SENT_TO_QUEUE_PROPERTY, "false");
+        firstTopicSend.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_IN_XA_TRANSACTION_PROPERTY, "false");
+        firstTopicSend.setStringProperty(ReplicaEventType.EVENT_TYPE_PROPERTY, ReplicaEventType.MESSAGE_SEND.toString());
+        firstTopicSend.setStringProperty(ReplicaSupport.MESSAGE_ID_PROPERTY, firstTopicSendMessageId);
+        list.add(new DummyMessageReference(new MessageId(firstTopicSendMessageId), firstTopicSend, 1));
+
+        final String secondTopicSendMessageId = "1:0:0:2";
+        final ActiveMQMessage secondTopicSend = new ActiveMQMessage();
+        secondTopicSend.setStringProperty(ReplicaSupport.ORIGINAL_MESSAGE_DESTINATION_PROPERTY, "VirtualTopic.Orders");
+        secondTopicSend.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_SENT_TO_QUEUE_PROPERTY, "false");
+        secondTopicSend.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_IN_XA_TRANSACTION_PROPERTY, "false");
+        secondTopicSend.setStringProperty(ReplicaEventType.EVENT_TYPE_PROPERTY, ReplicaEventType.MESSAGE_SEND.toString());
+        secondTopicSend.setStringProperty(ReplicaSupport.MESSAGE_ID_PROPERTY, secondTopicSendMessageId);
+        list.add(new DummyMessageReference(new MessageId(secondTopicSendMessageId), secondTopicSend, 1));
+
+        final String unrelatedTopicSendMessageId = "1:0:0:42"; // Not previously seen in the batch, should go to the same batch
+        final ActiveMQMessage unrelatedConsumerQueueAck = new ActiveMQMessage();
+        unrelatedConsumerQueueAck.setStringProperty(ReplicaSupport.ORIGINAL_MESSAGE_DESTINATION_PROPERTY, "Consumer.App1.VirtualTopic.Clients");
+        unrelatedConsumerQueueAck.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_SENT_TO_QUEUE_PROPERTY, "false");
+        unrelatedConsumerQueueAck.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_IN_XA_TRANSACTION_PROPERTY, "false");
+        unrelatedConsumerQueueAck.setStringProperty(ReplicaEventType.EVENT_TYPE_PROPERTY, ReplicaEventType.MESSAGE_ACK.toString());
+        unrelatedConsumerQueueAck.setProperty(ReplicaSupport.MESSAGE_IDS_PROPERTY, List.of(unrelatedTopicSendMessageId));
+        list.add(new DummyMessageReference(new MessageId(unrelatedTopicSendMessageId), unrelatedConsumerQueueAck, 1));
+
+        final ActiveMQMessage firstConsumerQueueAck = new ActiveMQMessage(); // Previously seen in the batch, should go to a new batch
+        firstConsumerQueueAck.setStringProperty(ReplicaSupport.ORIGINAL_MESSAGE_DESTINATION_PROPERTY, "Consumer.App1.VirtualTopic.Orders");
+        firstConsumerQueueAck.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_SENT_TO_QUEUE_PROPERTY, "false");
+        firstConsumerQueueAck.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_IN_XA_TRANSACTION_PROPERTY, "false");
+        firstConsumerQueueAck.setStringProperty(ReplicaEventType.EVENT_TYPE_PROPERTY, ReplicaEventType.MESSAGE_ACK.toString());
+        firstConsumerQueueAck.setProperty(ReplicaSupport.MESSAGE_IDS_PROPERTY, List.of(firstTopicSendMessageId));
+        list.add(new DummyMessageReference(new MessageId(firstTopicSendMessageId), firstConsumerQueueAck, 1));
+
+        final String thirdTopicSendMessageId = "1:0:0:3";
+        final ActiveMQMessage thirdTopicSend = new ActiveMQMessage();
+        thirdTopicSend.setStringProperty(ReplicaSupport.ORIGINAL_MESSAGE_DESTINATION_PROPERTY, "VirtualTopic.Orders");
+        thirdTopicSend.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_SENT_TO_QUEUE_PROPERTY, "false");
+        thirdTopicSend.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_IN_XA_TRANSACTION_PROPERTY, "false");
+        thirdTopicSend.setStringProperty(ReplicaEventType.EVENT_TYPE_PROPERTY, ReplicaEventType.MESSAGE_SEND.toString());
+        thirdTopicSend.setStringProperty(ReplicaSupport.MESSAGE_ID_PROPERTY, thirdTopicSendMessageId);
+        list.add(new DummyMessageReference(new MessageId(thirdTopicSendMessageId), thirdTopicSend, 1));
+
+        List<List<MessageReference>> batches = new ReplicaBatcher(replicaPolicy).batches(list);
+
+        assertThat(batches.size()).isEqualTo(2);
+
+        assertThat(batches.get(0).size()).isEqualTo(3);
+        assertThat(batches.get(0).get(0).getMessageId().toString()).isEqualTo(firstTopicSendMessageId);
+        assertThat(batches.get(0).get(1).getMessageId().toString()).isEqualTo(secondTopicSendMessageId);
+        assertThat(batches.get(0).get(2).getMessageId().toString()).isEqualTo(unrelatedTopicSendMessageId);
+
+        assertThat(batches.get(1).size()).isEqualTo(2);
+        assertThat(batches.get(1).get(0).getMessageId().toString()).isEqualTo(firstTopicSendMessageId);
+        assertThat(batches.get(1).get(1).getMessageId().toString()).isEqualTo(thirdTopicSendMessageId);
+    }
+
+    @Test
+    public void topicSendTriggeringBatchSplitBySize_ackLandsInSeparateBatch() throws Exception {
+        final ReplicaPolicy policy = new ReplicaPolicy();
+        policy.setMaxBatchSize(10);
+
+        final List<MessageReference> list = new ArrayList<>();
+
+        // Topic SEND "msg-1" — takes up most of the batch size budget
+        final ActiveMQMessage send1 = new ActiveMQMessage();
+        send1.setStringProperty(ReplicaSupport.ORIGINAL_MESSAGE_DESTINATION_PROPERTY, "topic://VirtualTopic.Orders");
+        send1.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_SENT_TO_QUEUE_PROPERTY, "false");
+        send1.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_IN_XA_TRANSACTION_PROPERTY, "false");
+        send1.setStringProperty(ReplicaEventType.EVENT_TYPE_PROPERTY, ReplicaEventType.MESSAGE_SEND.toString());
+        send1.setStringProperty(ReplicaSupport.MESSAGE_ID_PROPERTY, "msg-1");
+        list.add(new DummyMessageReference(new MessageId("1:0:0:1"), send1, 8));
+
+        // Topic SEND "msg-2" — exceeds maxBatchSize, triggers split
+        final ActiveMQMessage send2 = new ActiveMQMessage();
+        send2.setStringProperty(ReplicaSupport.ORIGINAL_MESSAGE_DESTINATION_PROPERTY, "topic://VirtualTopic.Orders");
+        send2.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_SENT_TO_QUEUE_PROPERTY, "false");
+        send2.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_IN_XA_TRANSACTION_PROPERTY, "false");
+        send2.setStringProperty(ReplicaEventType.EVENT_TYPE_PROPERTY, ReplicaEventType.MESSAGE_SEND.toString());
+        send2.setStringProperty(ReplicaSupport.MESSAGE_ID_PROPERTY, "msg-2");
+        list.add(new DummyMessageReference(new MessageId("1:0:0:2"), send2, 8));
+
+        // ACK for "msg-2" from Virtual Topic consumer queue, should trigger a new batch
+        final ActiveMQMessage ack = new ActiveMQMessage();
+        ack.setStringProperty(ReplicaSupport.ORIGINAL_MESSAGE_DESTINATION_PROPERTY, "queue://Consumer.App1.VirtualTopic.Orders");
+        ack.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_SENT_TO_QUEUE_PROPERTY, "false");
+        ack.setStringProperty(ReplicaSupport.IS_ORIGINAL_MESSAGE_IN_XA_TRANSACTION_PROPERTY, "false");
+        ack.setStringProperty(ReplicaEventType.EVENT_TYPE_PROPERTY, ReplicaEventType.MESSAGE_ACK.toString());
+        ack.setProperty(ReplicaSupport.MESSAGE_IDS_PROPERTY, List.of("msg-2"));
+        list.add(new DummyMessageReference(new MessageId("1:0:0:3"), ack, 1));
+
+        final List<List<MessageReference>> batches = new ReplicaBatcher(policy).batches(list);
+
+        assertThat(batches).hasSize(3);
+        assertThat(batches.get(0).get(0).getMessageId().toString()).isEqualTo("1:0:0:1");
+        assertThat(batches.get(1).get(0).getMessageId().toString()).isEqualTo("1:0:0:2");
+        assertThat(batches.get(2).get(0).getMessageId().toString()).isEqualTo("1:0:0:3");
     }
 
     private static class DummyMessageReference implements MessageReference {

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/replica/ReplicaPluginQueueTest.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/replica/ReplicaPluginQueueTest.java
@@ -532,4 +532,171 @@ public class ReplicaPluginQueueTest extends ReplicaPluginTestSupport {
         firstBrokerSession.close();
     }
 
+    public void testAllVirtualTopicMessagesAreReplicated() throws Exception {
+        final String virtualTopicName = "VirtualTopic." + getDestinationString();
+        final String firstConsumerQueueName = "Consumer.One." + virtualTopicName;
+        final String secondConsumerQueueName = "Consumer.Two." + virtualTopicName;
+
+        final Session firstBrokerSession = firstBrokerConnection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+        final Topic virtualTopic = new ActiveMQTopic(virtualTopicName);
+
+        final MessageProducer firstBrokerProducer = firstBrokerSession.createProducer(virtualTopic);
+        firstBrokerProducer.setDeliveryMode(javax.jms.DeliveryMode.PERSISTENT);
+
+        firstBrokerSession.createConsumer(new ActiveMQQueue(firstConsumerQueueName));
+        firstBrokerSession.createConsumer(new ActiveMQQueue(secondConsumerQueueName));
+
+        final int messageCount = 100;
+
+        for (int i = 0; i < messageCount; i++) {
+            ActiveMQTextMessage msg = new ActiveMQTextMessage();
+            msg.setText(getName());
+            firstBrokerProducer.send(msg);
+        }
+
+        waitUntilQueueExists(secondBroker, firstConsumerQueueName);
+        waitUntilQueueExists(secondBroker, secondConsumerQueueName);
+        waitUntilQueueHasMessages(secondBroker, firstConsumerQueueName, messageCount);
+        waitUntilQueueHasMessages(secondBroker, secondConsumerQueueName, messageCount);
+
+        firstBrokerSession.close();
+    }
+
+    public void testVirtualTopicFanOutAcksAreReplicated() throws Exception {
+        // Ref.: https://t.corp.amazon.com/V2193145703
+
+        final String virtualTopicName = "VirtualTopic." + getDestinationString();
+        final String firstConsumerQueueName = "Consumer.One." + virtualTopicName;
+        final String secondConsumerQueueName = "Consumer.Two." + virtualTopicName;
+
+        final int messagesToPublish = 13;
+        final int messagesToAcknowledge = 10;
+        final int expectedRemainingMessages = messagesToPublish - messagesToAcknowledge;
+
+        final Session firstBrokerSession = firstBrokerConnection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+        final Topic virtualTopic = new ActiveMQTopic(virtualTopicName);
+
+        final MessageProducer firstBrokerProducer = firstBrokerSession.createProducer(virtualTopic);
+        firstBrokerProducer.setDeliveryMode(javax.jms.DeliveryMode.PERSISTENT);
+
+        final MessageConsumer firstConsumer = firstBrokerSession.createConsumer(new ActiveMQQueue(firstConsumerQueueName));
+        final MessageConsumer secondConsumer = firstBrokerSession.createConsumer(new ActiveMQQueue(secondConsumerQueueName));
+
+        // Publish to the virtual topic
+        for (int i = 0; i < messagesToPublish; i++) {
+            ActiveMQTextMessage msg = new ActiveMQTextMessage();
+            msg.setText(getName());
+            firstBrokerProducer.send(msg);
+        }
+
+        // Consume messages from the Consumer Queues
+        for (int i = 0; i < messagesToAcknowledge; i++) {
+            final Message firstMsg = firstConsumer.receive(SHORT_TIMEOUT);
+            assertNotNull(firstMsg);
+            firstMsg.acknowledge();
+
+            final Message secondMsg = secondConsumer.receive(SHORT_TIMEOUT);
+            assertNotNull(secondMsg);
+            secondMsg.acknowledge();
+        }
+
+        // Consumer queues must have been consumed in the primary broker
+        waitUntilQueueHasMessages(firstBroker, firstConsumerQueueName, expectedRemainingMessages);
+        waitUntilQueueHasMessages(firstBroker, secondConsumerQueueName, expectedRemainingMessages);
+
+        // Consumer queues must have been replicated to the replica broker
+        waitUntilQueueExists(secondBroker, firstConsumerQueueName);
+        waitUntilQueueExists(secondBroker, secondConsumerQueueName);
+
+        // Primary broker replication backlog is empty (no more messages pending replication)
+        waitUntilReplicationQueueIsEmpty(firstBroker);
+
+        // The consumer queues state in the replica broker must match the one in the primary broker
+        waitUntilQueueHasMessages(secondBroker, firstConsumerQueueName, expectedRemainingMessages);
+        waitUntilQueueHasMessages(secondBroker, secondConsumerQueueName, expectedRemainingMessages);
+
+        firstBrokerSession.close();
+    }
+
+    public void test() throws Exception {
+        // Ref.: https://t.corp.amazon.com/V2193145703
+
+        final String topicName = "MyDurableTopics." + getDestinationString();
+
+        // Must be the same on Primary and Replica brokers
+        final String firstConsumerName = "MyFirstConsumer";
+        final String secondConsumerName = "MySecondConsumer";
+        final String clientId = "MyClientId";
+
+        final int messagesToPublish = 13;
+        final int messagesToAcknowledge = 10;
+        final int expectedRemainingMessages = messagesToPublish * 2 - messagesToAcknowledge;
+
+        firstBrokerConnection.close();
+        firstBrokerConnection = firstBrokerConnectionFactory.createConnection();
+        firstBrokerConnection.setClientID(clientId);
+        firstBrokerConnection.start();
+        final Session firstBrokerSession = firstBrokerConnection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+        final Topic virtualTopic = new ActiveMQTopic(topicName);
+
+        final MessageProducer firstBrokerProducer = firstBrokerSession.createProducer(virtualTopic);
+        firstBrokerProducer.setDeliveryMode(javax.jms.DeliveryMode.PERSISTENT);
+
+        final MessageConsumer firstConsumer = firstBrokerSession.createDurableConsumer(new ActiveMQTopic(topicName), firstConsumerName);
+        final MessageConsumer secondConsumer = firstBrokerSession.createDurableConsumer(new ActiveMQTopic(topicName), secondConsumerName);
+
+        // Publish to the virtual topic
+        for (int i = 0; i < messagesToPublish; i++) {
+            ActiveMQTextMessage msg = new ActiveMQTextMessage();
+            msg.setText(getName());
+            firstBrokerProducer.send(msg);
+        }
+
+        // Consume some messages
+        for (int i = 0; i < messagesToAcknowledge; i++) {
+            firstConsumer.receive();
+            secondConsumer.receive();
+        }
+
+        // Publish another batch of messages
+        for (int i = 0; i < messagesToPublish; i++) {
+            ActiveMQTextMessage msg = new ActiveMQTextMessage();
+            msg.setText(getName());
+            firstBrokerProducer.send(msg);
+        }
+
+        // Close first consumer, leave second consumer connected
+        firstConsumer.close();
+
+        // Consumer queues must have been replicated to the replica broker
+        waitUntilTopicExists(secondBroker, topicName);
+
+        // Primary broker replication backlog is empty (no more messages pending replication)
+        waitUntilReplicationQueueIsEmpty(firstBroker);
+
+        secondBrokerConnection.close();
+        secondBrokerConnection = secondBrokerConnectionFactory.createConnection();
+        secondBrokerConnection.setClientID(clientId);
+        secondBrokerConnection.start();
+        final Session secondBrokerSession = secondBrokerConnection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
+
+        final MessageConsumer replicaFirstConsumer = secondBrokerSession.createDurableConsumer(new ActiveMQTopic(topicName), firstConsumerName);
+        final MessageConsumer replicaSecondConsumer = secondBrokerSession.createDurableConsumer(new ActiveMQTopic(topicName), secondConsumerName);
+
+        waitForCondition("Pending messages to first durable consumer must have been replicated", () -> {
+            for (int i = 0; i < expectedRemainingMessages; i++) {
+                replicaFirstConsumer.receive();
+            }
+            return true;
+        });
+
+        waitForCondition("Pending messages to second durable consumer must have been replicated", () -> {
+            for (int i = 0; i < expectedRemainingMessages; i++) {
+                replicaSecondConsumer.receive();
+            }
+            return true;
+        });
+
+        firstBrokerSession.close();
+    }
 }

--- a/activemq-unit-tests/src/test/java/org/apache/activemq/broker/replica/ReplicaPluginTestSupport.java
+++ b/activemq-unit-tests/src/test/java/org/apache/activemq/broker/replica/ReplicaPluginTestSupport.java
@@ -33,6 +33,8 @@ import org.apache.activemq.replica.util.ReplicaSupport;
 import org.apache.activemq.replica.jmx.ReplicationViewMBean;
 import org.apache.activemq.util.Wait;
 import org.apache.commons.io.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.jms.ConnectionFactory;
 import javax.management.MBeanServer;
@@ -44,6 +46,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.util.stream.Stream;
 
 public abstract class ReplicaPluginTestSupport extends AutoFailTestSupport {
 
@@ -52,6 +55,8 @@ public abstract class ReplicaPluginTestSupport extends AutoFailTestSupport {
 
     protected static final String FIRST_KAHADB_DIRECTORY = "target/activemq-data/first/";
     protected static final String SECOND_KAHADB_DIRECTORY = "target/activemq-data/second/";
+
+    protected static final Logger LOG = LoggerFactory.getLogger(ReplicaPluginTestSupport.class);
 
     protected String firstBindAddress = "vm://firstBroker";
     protected String firstReplicaBindAddress = "tcp://localhost:61610";
@@ -258,29 +263,64 @@ public abstract class ReplicaPluginTestSupport extends AutoFailTestSupport {
         }
     }
 
-    protected void waitForCondition(Runnable condition) throws Exception {
-        assertTrue(Wait.waitFor(() -> {
+    protected void waitForCondition(final String message, final long duration, final Wait.Condition condition) throws Exception {
+        assertTrue(message, Wait.waitFor(() -> {
             try {
-                condition.run();
-                return true;
+                return condition.isSatisified();
             } catch (Exception|Error e) {
                 e.printStackTrace();
                 return false;
             }
-        }, Wait.MAX_WAIT_MILLIS * 5));
+        }, duration));
+    }
+
+    protected void waitForCondition(final String message, final Wait.Condition condition) throws Exception {
+        waitForCondition(message, Wait.MAX_WAIT_MILLIS*2, condition);
+    }
+
+    protected void waitForCondition(Runnable condition) throws Exception {
+        waitForCondition("", Wait.MAX_WAIT_MILLIS * 5, () -> {
+            condition.run();
+            return true;
+        });
     }
 
     protected void waitUntilReplicationQueueHasConsumer(BrokerService broker) throws Exception {
-        assertTrue("Replication Main Queue has Consumer",
-                Wait.waitFor(() -> {
-                    try {
-                        QueueViewMBean brokerMainQueueView = getReplicationQueueView(broker, ReplicaSupport.MAIN_REPLICATION_QUEUE_NAME);
-                        return brokerMainQueueView.getConsumerCount() > 0;
-                    } catch (Exception e) {
-                        e.printStackTrace();
-                        return false;
-                    }
-                }, Wait.MAX_WAIT_MILLIS*2));
+        waitForCondition("Replication Main Queue has Consumer", () -> {
+            QueueViewMBean brokerMainQueueView = getReplicationQueueView(broker, ReplicaSupport.MAIN_REPLICATION_QUEUE_NAME);
+            return brokerMainQueueView.getConsumerCount() > 0;
+        });
     }
 
+    protected void waitUntilReplicationQueueIsEmpty(final BrokerService broker) throws Exception {
+        waitForCondition("Replication Main Queue is empty", () -> {
+            final long queueSize = getReplicationQueueView(broker, ReplicaSupport.MAIN_REPLICATION_QUEUE_NAME).getQueueSize();
+            LOG.info("Replication Queue has {} messages (expected 0)", queueSize);
+            return queueSize == 0;
+        });
+    }
+
+    protected void waitUntilQueueExists(final BrokerService broker, final String name) throws Exception {
+        waitForCondition(String.format("Queue %s exists", name), () -> {
+            final BrokerViewMBean brokerViewMBean = getBrokerView(broker);
+            return Stream.of(brokerViewMBean.getQueues())
+                    .anyMatch(queue -> queue.toString().contains(name));
+        });
+    }
+
+    protected void waitUntilQueueHasMessages(final BrokerService broker, final String name, final long expectedNumberOfMessages) throws Exception {
+        waitForCondition(String.format("Queue %s has %d messages", name, expectedNumberOfMessages), () -> {
+            final long queueSize = getQueueView(broker, name).getQueueSize();
+            LOG.info("Queue {} ({}) has {} messages (expected {})", name, broker.getBrokerName(), queueSize, expectedNumberOfMessages);
+            return queueSize == expectedNumberOfMessages;
+        });
+    }
+
+    protected void waitUntilTopicExists(final BrokerService broker, final String name) throws Exception {
+        waitForCondition(String.format("Topic %s exists", name), () -> {
+            final BrokerViewMBean brokerViewMBean = getBrokerView(broker);
+            return Stream.of(brokerViewMBean.getTopics())
+                    .anyMatch(topic -> topic.toString().contains(name));
+        });
+    }
 }


### PR DESCRIPTION
**Issue**

Messages published to Virtual Topic consumer queues are consumed on the Primary Broker, but still show up in the Replica Broker. For example, when publishing to `VirtualTopic.foo` and having one consumer on `Consumer.test1.VirtualTopic.foo`,  the number of messages in the later queue diverges between Primary and Replica:

Primary:

```
Name                                                Queue Size  Producer #  Consumer #   Enqueue #   Dequeue #   Forward #    Memory %
ActiveMQ.Advisory.Connection                                 0           0           0           5           0           0           0
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Intermediate.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Role.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Sequence.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.Consumer.test1.VirtualTopic.foo           0           0           0           2           0           0           0
ActiveMQ.Advisory.MasterBroker                               0           0           0           1           0           0           0
ActiveMQ.Advisory.Producer.Topic.VirtualTopic.foo            0           0           0           2           0           0           0
ActiveMQ.Advisory.Queue                                      0           0           1          13           5           0           0
ActiveMQ.Advisory.TempQueue                                  0           0           2           0           0           0           0
ActiveMQ.Advisory.TempTopic                                  0           0           2           0           0           0           0
ActiveMQ.Advisory.Topic                                      0           0           1           4           2           0           0
ActiveMQ.Plugin.Replication.Intermediate.Queue               0           0           1        8854        8854           0           0
ActiveMQ.Plugin.Replication.Queue                            0           0           1          20          20           0           0
ActiveMQ.Plugin.Replication.Role.Advisory.Topic              0           0           0           0           0           0           0
ActiveMQ.Plugin.Replication.Role.Queue                       0           0           1           0           0           0           0
ActiveMQ.Plugin.Replication.Sequence.Queue                   1           0           2          40          39           0           0
Consumer.test1.VirtualTopic.foo                              0           0           0        2950        2950           0           0
VirtualTopic.foo                                             0           0           0        2950           0           0           0
```

Replica:

```
Name                                                Queue Size  Producer #  Consumer #   Enqueue #   Dequeue #   Forward #    Memory %
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Role.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Sequence.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.Consumer.test1.VirtualTopic.foo           0           0           0          20           0           0           0
ActiveMQ.Advisory.MasterBroker                               0           0           0           1           0           0           0
ActiveMQ.Advisory.Queue                                      0           0           0           3           0           0           0
ActiveMQ.Advisory.SlowConsumer.Queue.Consumer.test1.VirtualTopic.foo           0           0           0          10           0           0           0
ActiveMQ.Advisory.Topic                                      0           0           0           2           0           0           0
ActiveMQ.Plugin.Replication.Role.Advisory.Topic              0           0           0           0           0           0           0
ActiveMQ.Plugin.Replication.Role.Queue                       0           0           1           0           0           0           0
ActiveMQ.Plugin.Replication.Sequence.Queue                   1           0           1          20          19           0           0
Consumer.test1.VirtualTopic.foo                           2940           0           0        2950          10           0           4
VirtualTopic.foo                                             0           0           0        2950           0           0           0
```

Replica logs show:

```
 WARN | Duplicate message add attempt rejected. Destination: QUEUE://Consumer.test1.VirtualTopic.foo, Message id: ID:bcd07446c7ec-51783-1780015436336-1:1:1:1:165
 WARN | queue://Consumer.test1.VirtualTopic.foo, subscriptions=0, memory=0%, size=0, pending=0 messageStore indicated duplicate add attempt for ID:bcd07446c7ec-51783-1780015436336-1:1:1:1:165, suppressing duplicate dispatch
 WARN | Duplicate message add attempt rejected. Destination: QUEUE://Consumer.test1.VirtualTopic.foo, Message id: ID:bcd07446c7ec-51783-1780015436336-1:1:1:1:498
 WARN | queue://Consumer.test1.VirtualTopic.foo, subscriptions=0, memory=0%, size=330, pending=0 messageStore indicated duplicate add attempt for ID:bcd07446c7ec-51783-1780015436336-1:1:1:1:498, suppressing duplicate dispatch
 WARN | Duplicate message add attempt rejected. Destination: QUEUE://Consumer.test1.VirtualTopic.foo, Message id: ID:bcd07446c7ec-51783-1780015436336-1:1:1:1:831
...
```

**Root Cause**

There are two issues playing a role here:

**1. Consumer queue ACKs get compacted:**

This issue happens due to this sequence of events:

A message - M1 - is published to the Virtual Topic (for example, VirtualTopic.foo) in the Primary broker.

The Primary broker fans out M1 to the consumer queue(s) (for example, Consumer.test1.VirtualTopic.foo), lets call this message M2

Both M1 and M2 become candidates for replication.

1.2. M1 will always be replicated

1.3. If M2 is consumed before being replicated:

1.3.1. The CRDR plugin in the Primary broker detects the "send" and "acknowledge" events for M2. Since they "cancel each other", M2 Send and Ack aren't replicated (avoids replicating already consumed messages)

1.3.2. The Replica broker receives M1 and fans out to the consumer queues (Consumer.CEG.VirtualTopic.AppOp.Default), lets call this message M3

1.3.3. The Replica broker will never receive an Acknowledgment for M3

1.4. If M2 is consumed after being replicated:

1.4.1. M2 is replicated. Eventually the corresponding ACK event for M2 is also replicated

1.4.2. The Replica broker receives M1 and fans out to the consumer queues (Consumer.CEG.VirtualTopic.AppOp.Default), lets call this message M4

1.4.3. The Replica broker receives M2 and detects that M2 and M4 are the same message (same Message ID - inherited from M1- and same destination).

1.4.4. M2 is dropped, no issue.

1.4.5. The Replica broker receives the ACK event for M2, it will acknowledge M4 (since M4 and M2 are equivalent), no issue.

Path `1.3` is the problematic one, since it cause messages to get stuck in the Replica broker. Path 1.4 does not generate any issue other than unecessary replication traffic.

An interesting thing is that this issue does not happen with Composite Queues because they are explicitily handled by the CRDR plugin. When looking into this issue I didn't find any equivalent handling for Virtual Topics.

**2. Replica replays SEND and ACK in the same transaction**

If two events (for example, Send and Ack) are batched together for replication by the Primary broker, then the Replica broker will replay them within the same transaction (this does not apply if the customer used XA transactions to publish and consume the message). Meaning the Replica will fannout the Virtual Topic message to the consumer queues in the same transaction where it will try to acknowledge these same messages. Because the messages are not commit yet, they are not visible, therefore the broker fails to find and acknowledge them. Again it results in messages being stuck in the Replica broker.


**Solution**

1. Change the `ReplicaDestinationFilter` to  not replicate messages which are Virtual Topic fan outs (for example, replicate SEND to `VirtualTopic.foo` but not to `Consumer.test1.VirtualTopic.foo`). Let the Replica fan out when the topic message is replicated.
2. Change the `ReplicaBatcher` to not include SENDs to Topics and 

**Testing**

1. Tested locally, the behavior is not seen after this changes. In the same example:

Primary

```
Name                                                Queue Size  Producer #  Consumer #   Enqueue #   Dequeue #   Forward #    Memory %
ActiveMQ.Advisory.Connection                                 0           0           0           5           0           0           0
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Intermediate.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Role.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Sequence.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.Consumer.test1.VirtualTopic.foo           0           0           0           2           0           0           0
ActiveMQ.Advisory.MasterBroker                               0           0           0           1           0           0           0
ActiveMQ.Advisory.Producer.Topic.VirtualTopic.foo            0           0           0           2           0           0           0
ActiveMQ.Advisory.Queue                                      0           0           1          13           5           0           0
ActiveMQ.Advisory.TempQueue                                  0           0           2           0           0           0           0
ActiveMQ.Advisory.TempTopic                                  0           0           2           0           0           0           0
ActiveMQ.Advisory.Topic                                      0           0           1           4           2           0           0
ActiveMQ.Plugin.Replication.Intermediate.Queue               0           0           1        3669        3669           0           0
ActiveMQ.Plugin.Replication.Queue                            0           0           1        1830        1830           0           0
ActiveMQ.Plugin.Replication.Role.Advisory.Topic              0           0           0           0           0           0           0
ActiveMQ.Plugin.Replication.Role.Queue                       0           0           1           0           0           0           0
ActiveMQ.Plugin.Replication.Sequence.Queue                   1           0           2        1845        1844           0           0
Consumer.test1.VirtualTopic.foo                              0           0           0        1833        1833           0           0
VirtualTopic.foo                                             0           0           0        1833           0           0           0
lemoss@bcd07446c7ec ~/m/r/bin> ./region1 dstat --pid $(cat /Users/lemoss/moodys/region2/data/activemq.pid)
```

Replica

```
Name                                                Queue Size  Producer #  Consumer #   Enqueue #   Dequeue #   Forward #    Memory %
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Role.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.ActiveMQ.Plugin.Replication.Sequence.Queue           0           0           0           0           0           0           0
ActiveMQ.Advisory.Consumer.Queue.Consumer.test1.VirtualTopic.foo           0           0           0        3666           0           0           0
ActiveMQ.Advisory.MasterBroker                               0           0           0           1           0           0           0
ActiveMQ.Advisory.Queue                                      0           0           0           3           0           0           0
ActiveMQ.Advisory.SlowConsumer.Queue.Consumer.test1.VirtualTopic.foo           0           0           0        1705           0           0           0
ActiveMQ.Advisory.Topic                                      0           0           0           2           0           0           0
ActiveMQ.Plugin.Replication.Role.Advisory.Topic              0           0           0           0           0           0           0
ActiveMQ.Plugin.Replication.Role.Queue                       0           0           1           0           0           0           0
ActiveMQ.Plugin.Replication.Sequence.Queue                   1           0           1        1830        1829           0           0
Consumer.test1.VirtualTopic.foo                              0           0           0        1833        1833           0           0
VirtualTopic.foo                                             0           0           0        1833           0           0           0
```

2. Added unit tests for both changes.
