### PR TITLE
Retries broker.processDispatchNotification() when message is not found.

### DIFF
--- a/activemq-broker/src/main/java/org/apache/activemq/replica/replica/ReplicaBrokerEventListener.java
+++ b/activemq-broker/src/main/java/org/apache/activemq/replica/replica/ReplicaBrokerEventListener.java
@@ -69,6 +69,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -76,6 +77,9 @@ import java.util.stream.Collectors;
 import static java.util.Objects.requireNonNull;
 
 public class ReplicaBrokerEventListener implements MessageListener {
+
+    private static final int MAX_DISPATCH_RETRY_ATTEMPTS = 3;
+    private static final long DISPATCH_RETRY_SLEEP_MS = 10;
 
     private static final String REPLICATION_CONSUMER_CLIENT_ID = "DUMMY_REPLICATION_CONSUMER";
     private static final String SEQUENCE_NAME = "replicaSeq";
@@ -473,18 +477,31 @@ public class ReplicaBrokerEventListener implements MessageListener {
     private List<String> messageDispatch(MessageAck ack, List<String> messageIdsToAck) throws Exception {
         List<String> existingMessageIdsToAck = new ArrayList<>();
         for (String messageId : messageIdsToAck) {
-            try {
-                broker.processDispatchNotification(getMessageDispatchNotification(ack, messageId));
+            if (tryMessageDispatchWithRetries(ack, messageId)) {
                 existingMessageIdsToAck.add(messageId);
+            }
+        }
+        return existingMessageIdsToAck;
+    }
+
+    private boolean tryMessageDispatchWithRetries(final MessageAck ack, final String messageIdToAck) throws Exception {
+        for (int i=0; i<MAX_DISPATCH_RETRY_ATTEMPTS; i++) {
+            try {
+                broker.processDispatchNotification(getMessageDispatchNotification(ack, messageIdToAck));
+                return true;
             } catch (JMSException e) {
                 if (e.getMessage().contains("Slave broker out of sync with master")) {
-                    logger.warn("Skip MESSAGE_ACK processing event due to non-existing message [{}]", messageId);
+                    logger.debug(e.getMessage());
+                    logger.warn("Failed to dispatch MESSAGE_ACK processing event due to non-existing message [{}] during attempt {}. Will retry.", messageIdToAck, i);
+                    TimeUnit.MILLISECONDS.sleep(DISPATCH_RETRY_SLEEP_MS);
                 } else {
                     throw e;
                 }
             }
         }
-        return existingMessageIdsToAck;
+
+        logger.warn("Skip MESSAGE_ACK processing event due to non-existing message [{}].", messageIdToAck);
+        return false;
     }
 
     private static MessageDispatchNotification getMessageDispatchNotification(MessageAck ack, String messageId) {

--- a/activemq-broker/src/test/java/org/apache/activemq/replica/replica/ReplicaBrokerEventListenerTest.java
+++ b/activemq-broker/src/test/java/org/apache/activemq/replica/replica/ReplicaBrokerEventListenerTest.java
@@ -693,6 +693,43 @@ public class ReplicaBrokerEventListenerTest {
     }
 
     @Test
+    public void canHandleEventOfType_MESSAGE_ACK_retryWhenMessageNotFound() throws Exception {
+        listener.sequence = null;
+        MessageId messageId = new MessageId("1:1");
+        when(broker.getDestinations()).thenReturn(new ActiveMQDestination[]{testQueue});
+        when(transactionBroker.getTransaction(any(), any(), anyBoolean())).thenReturn(mock(Transaction.class));
+
+        MessageAck ack = new MessageAck();
+        ConsumerId consumerId = new ConsumerId("2:2:2:2");
+        ack.setConsumerId(consumerId);
+        ack.setDestination(testQueue);
+
+        final JMSException transientException = new JMSException("Slave broker out of sync with master - Message: transient error");
+
+        doThrow(transientException)
+                .doThrow(transientException)
+                .doNothing()
+                .when(broker).processDispatchNotification(any(MessageDispatchNotification.class));
+
+        ActiveMQMessage replicaEventMessage = spy(new ActiveMQMessage());
+        ReplicaEvent event = new ReplicaEvent()
+                .setEventType(ReplicaEventType.MESSAGE_ACK)
+                .setEventData(eventSerializer.serializeReplicationData(ack))
+                .setReplicationProperty(ReplicaSupport.MESSAGE_IDS_PROPERTY, Collections.singletonList(messageId.toString()));
+        replicaEventMessage.setMessageId(new MessageId("1:1:1:1"));
+        replicaEventMessage.setContent(event.getEventData());
+        replicaEventMessage.setStringProperty(ReplicaEventType.EVENT_TYPE_PROPERTY, event.getEventType().name());
+        replicaEventMessage.setStringProperty(ReplicaSupport.SEQUENCE_PROPERTY, "0");
+        replicaEventMessage.setIntProperty(ReplicaSupport.VERSION_PROPERTY, ReplicaSupport.CURRENT_VERSION);
+        replicaEventMessage.setProperties(event.getReplicationProperties());
+
+        listener.onMessage(replicaEventMessage);
+
+        verify(broker, times(3)).processDispatchNotification(any(MessageDispatchNotification.class));
+        verify(broker).acknowledge(any(), any());
+    }
+
+    @Test
     public void canHandleEventOfType_MESSAGE_ACK_whenDestinationNotExist() throws Exception {
         listener.sequence = null;
         MessageId messageId = new MessageId("1:1");


### PR DESCRIPTION
I found cases where the replica broker would eventually log `Skip MESSAGE_ACK processing event due to non-existing message` and end up with message counts diverging from the primary.

While I was not able to identify reliable reproduction steps, I was able to confirm that both SEND and ACK messages were correctly replicated. However, the replica can't find the matching SEND when replaying an ACK.

**Root Cause**

Hyphotesis is the Queue  hasn't yet (or couldn't) page in messages when an ACK is processed very close to its respective SEND.

**Fix**

This is a mitigation to this problem, if dispatching the ACK fails the ReplicaBrokerEventListener retries.

**Testing**

Unit Test.

When trying to reproduce the issue locally I can cause the` Failed to dispatch MESSAGE_ACK processing event due to non-existing message [{}] during attempt {}. Will retry`. case to eventually happen, always for the first attempt.